### PR TITLE
Fix exception on opening Excel file in Editor.

### DIFF
--- a/src/Products/Editor/Controllers/EditorApiController.cs
+++ b/src/Products/Editor/Controllers/EditorApiController.cs
@@ -100,7 +100,7 @@ namespace GroupDocs.Total.MVC.Products.Editor.Controllers
             }
             catch (System.Exception ex)
             {
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -228,7 +228,7 @@ namespace GroupDocs.Total.MVC.Products.Editor.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -436,7 +436,7 @@ namespace GroupDocs.Total.MVC.Products.Editor.Controllers
 
             if (options is SpreadsheetToHtmlOptions)
             {
-                options.TextOptions = options.TextLoadOptions(",");
+                options.TextOptions = new SpreadsheetToHtmlOptions.TextLoadOptions(",");
             }
             else
             {


### PR DESCRIPTION
Replicated fix from the https://github.com/groupdocs-editor/GroupDocs.Editor-for-.NET-MVC/pull/11, additionally status `OK` was replaced by `InternalServerError` for responses from catch blocks. 