### PR TITLE
Fixed QR-codes with non-latin chars via API version update.

### DIFF
--- a/src/GroupDocs.Total.MVC.csproj
+++ b/src/GroupDocs.Total.MVC.csproj
@@ -63,8 +63,8 @@
     <Reference Include="GroupDocs.Metadata, Version=20.1.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Metadata.20.1.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Signature, Version=20.3.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Signature.20.3.0\lib\net20\GroupDocs.Signature.dll</HintPath>
+    <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Viewer, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Viewer.20.4.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
@@ -78,8 +78,8 @@
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>True</Private>

--- a/src/Web.config
+++ b/src/Web.config
@@ -55,10 +55,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
@@ -105,6 +101,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/packages.config
+++ b/src/packages.config
@@ -7,7 +7,7 @@
   <package id="GroupDocs.Conversion" version="20.3.0" targetFramework="net45" />
   <package id="GroupDocs.Editor" version="20.2.0" targetFramework="net45" />
   <package id="GroupDocs.Metadata" version="20.1.0" targetFramework="net45" />
-  <package id="GroupDocs.Signature" version="20.3.0" targetFramework="net45" />
+  <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Viewer" version="20.4.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
@@ -25,7 +25,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Moq" version="4.10.1" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Node-Kit" version="11.1.0.1" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
Replicated changes from https://github.com/groupdocs-signature/GroupDocs.Signature-for-.NET-MVC/pull/33.