### PR TITLE
Add usage of the showGridLines option.

### DIFF
--- a/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
+++ b/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
@@ -26,6 +26,12 @@ namespace GroupDocs.Total.MVC.Products.Common.Entity.Web
         [JsonProperty]
         private bool printAllowed = true;
 
+        /// <summary>
+        /// Document show grid lines flag (for Excel files). 
+        /// </summary>
+        [JsonProperty]
+        private bool showGridLines = true;
+
         public void SetPrintAllowed(bool allowed)
         {
             this.printAllowed = allowed;
@@ -34,6 +40,16 @@ namespace GroupDocs.Total.MVC.Products.Common.Entity.Web
         public bool GetPrintAllowed()
         {
             return this.printAllowed;
+        }
+
+        public void SetShowGridLines(bool show)
+        {
+            this.showGridLines = show;
+        }
+
+        public bool GetShowGridLines()
+        {
+            return this.showGridLines;
         }
 
         public void SetGuid(string guid)

--- a/src/Products/Viewer/Cache/HtmlViewer.cs
+++ b/src/Products/Viewer/Cache/HtmlViewer.cs
@@ -55,8 +55,7 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Cache
 
             htmlViewOptions.SpreadsheetOptions = SpreadsheetOptions.ForOnePagePerSheet();
             htmlViewOptions.SpreadsheetOptions.TextOverflowMode = TextOverflowMode.HideText;
-            htmlViewOptions.SpreadsheetOptions.RenderGridLines = true;
-            htmlViewOptions.SpreadsheetOptions.TextOverflowMode = TextOverflowMode.HideText;
+            htmlViewOptions.SpreadsheetOptions.RenderGridLines = globalConfiguration.GetViewerConfiguration().GetShowGridLines();
 
             SetWatermarkOptions(htmlViewOptions);
 

--- a/src/Products/Viewer/Config/ViewerConfiguration.cs
+++ b/src/Products/Viewer/Config/ViewerConfiguration.cs
@@ -52,6 +52,9 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Config
         private bool printAllowed = true;
 
         [JsonProperty]
+        private bool showGridLines = true;
+
+        [JsonProperty]
         private string cacheFolderName = "cache";
 
         /// <summary>
@@ -96,6 +99,7 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Config
             this.saveRotateState = valuesGetter.GetBooleanPropertyValue("saveRotateState", this.saveRotateState);
             this.watermarkText = valuesGetter.GetStringPropertyValue("watermarkText", this.watermarkText);
             this.printAllowed = valuesGetter.GetBooleanPropertyValue("printAllowed", this.printAllowed);
+            this.showGridLines = valuesGetter.GetBooleanPropertyValue("showGridLines", this.showGridLines);
         }
 
         private static bool IsFullPath(string path)
@@ -244,6 +248,16 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Config
         public bool GetPrintAllowed()
         {
             return this.printAllowed;
+        }
+
+        public void SetShowGridLines(bool showGridLines)
+        {
+            this.showGridLines = showGridLines;
+        }
+
+        public bool GetShowGridLines()
+        {
+            return this.showGridLines;
         }
     }
 }

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -88,6 +88,10 @@ viewer:
   # Set false to ignore document print security
   # Set true to check document print security
   printAllowed: true
+  # Adds/removes grid lines in the excel documents
+  # presentation regardless of whether they are in
+  # the document itself or not
+  showGridLines: false
 
 ################################################
 # GroupDocs.Signature configurations


### PR DESCRIPTION
**Problem:**
We do not have such option in Total repository.

**Solution:**
Option was added into configuration file and it's usage was replicated from stand-alone Viewer-MVC repository.

**Screenshots:**
_Option `showGridLines` is true:_
![gridlines_true](https://user-images.githubusercontent.com/17431807/99373408-6fde1280-28d2-11eb-83a0-1bb535905f04.png)

_Option `showGridLines` is false (more rows/columns):_
![gridlines_false](https://user-images.githubusercontent.com/17431807/99373424-74a2c680-28d2-11eb-9a8f-92fde2909386.png)

_Option `showGridLines` is false (less rows/columns):_
![gridlines_false_2](https://user-images.githubusercontent.com/17431807/99373761-d82cf400-28d2-11eb-8aa4-a40d01fe9c6f.png)