### PR TITLE
Update library API version to fix summary navigation.

### DIFF
--- a/src/GroupDocs.Total.MVC.csproj
+++ b/src/GroupDocs.Total.MVC.csproj
@@ -69,8 +69,8 @@
     <Reference Include="GroupDocs.Search, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Search.20.4.0\lib\net20\GroupDocs.Search.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Viewer, Version=20.7.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.20.7.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.20.11.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/src/packages.config
+++ b/src/packages.config
@@ -9,7 +9,7 @@
   <package id="GroupDocs.Metadata" version="20.9.0" targetFramework="net45" />
   <package id="GroupDocs.Search" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
-  <package id="GroupDocs.Viewer" version="20.7.0" targetFramework="net45" />
+  <package id="GroupDocs.Viewer" version="20.11.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />


### PR DESCRIPTION
Replicated changes from: https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-MVC/pull/77.