### PR TITLE
Update API versions, show excel sheets headings.

### DIFF
--- a/src/GroupDocs.Total.MVC.csproj
+++ b/src/GroupDocs.Total.MVC.csproj
@@ -48,26 +48,26 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Annotation, Version=20.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Annotation.20.6.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
+    <Reference Include="GroupDocs.Annotation, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Annotation.20.11.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Comparison, Version=20.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Comparison.20.6.0\lib\net20\GroupDocs.Comparison.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Conversion, Version=20.3.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Conversion.20.3.0\lib\net20\GroupDocs.Conversion.dll</HintPath>
+    <Reference Include="GroupDocs.Conversion, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Conversion.20.11.0\lib\net20\GroupDocs.Conversion.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Editor, Version=20.8.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Editor.20.8.0\lib\net20\GroupDocs.Editor.dll</HintPath>
+    <Reference Include="GroupDocs.Editor, Version=20.9.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Editor.20.9.0\lib\net20\GroupDocs.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Metadata, Version=20.9.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Metadata.20.9.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
+    <Reference Include="GroupDocs.Metadata, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Metadata.20.11.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
+    <Reference Include="GroupDocs.Search, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Search.20.11.0\lib\net20\GroupDocs.Search.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Search, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Search.20.4.0\lib\net20\GroupDocs.Search.dll</HintPath>
+    <Reference Include="GroupDocs.Signature, Version=20.9.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Signature.20.9.0\lib\net20\GroupDocs.Signature.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Viewer, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Viewer.20.11.0\lib\net20\GroupDocs.Viewer.dll</HintPath>

--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -209,7 +209,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
 
                 using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(documentGuid, GetLoadOptions(password)))
                 {
-                    using (var memoryStream = RenderPageToMemoryStream(annotator, pageNumber, documentGuid, password))
+                    using (var memoryStream = RenderPageToMemoryStream(annotator, pageNumber))
                     {
                         bytes = memoryStream.ToArray();
                     }
@@ -248,7 +248,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             for (int i = 0; i < pages.PageCount; i++)
             {
                 byte[] bytes;
-                using (var memoryStream = RenderPageToMemoryStream(annotator, i + 1, documentGuid, password))
+                using (var memoryStream = RenderPageToMemoryStream(annotator, i + 1))
                 {
                     bytes = memoryStream.ToArray();
                 }
@@ -260,7 +260,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             return allPages;
         }
 
-        static MemoryStream RenderPageToMemoryStream(GroupDocs.Annotation.Annotator annotator, int pageNumberToRender, string documentGuid, string password)
+        static MemoryStream RenderPageToMemoryStream(GroupDocs.Annotation.Annotator annotator, int pageNumberToRender)
         {
             MemoryStream result = new MemoryStream();
 
@@ -529,7 +529,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             {
                 using (Stream inputStream = File.Open(documentGuid, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
                 {
-                    using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(inputStream, GetLoadOptions(password, true)))
+                    using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(inputStream, GetLoadOptions(password)))
                     {
                         annotator.Save(tempPath, new SaveOptions { AnnotationTypes = AnnotationType.None });
                     }
@@ -551,7 +551,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             return tempPath;
         }
 
-        private static LoadOptions GetLoadOptions(string password, bool importAnnotations = false)
+        private static LoadOptions GetLoadOptions(string password)
         {
             LoadOptions loadOptions = new LoadOptions
             {

--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -156,7 +156,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
 
                 if (loadAllPages)
                 {
-                    pagesContent = GetAllPagesContent(annotator, password, documentGuid, info);
+                    pagesContent = GetAllPagesContent(annotator, info);
                 }
 
                 for (int i = 0; i < info.PageCount; i++)
@@ -240,7 +240,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             }
         }
 
-        private static List<string> GetAllPagesContent(GroupDocs.Annotation.Annotator annotator, string password, string documentGuid, IDocumentInfo pages)
+        private static List<string> GetAllPagesContent(GroupDocs.Annotation.Annotator annotator, IDocumentInfo pages)
         {
             List<string> allPages = new List<string>();
 
@@ -497,7 +497,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
                     using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(outputStream, GetLoadOptions(password)))
                     {
                         IDocumentInfo info = annotator.Document.GetDocumentInfo();
-                        List<string> pagesContent = GetAllPagesContent(annotator, password, documentGuid, info);
+                        List<string> pagesContent = GetAllPagesContent(annotator, info);
 
                         for (int i = 0; i < info.PageCount; i++)
                         {

--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -156,7 +156,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
 
                 if (loadAllPages)
                 {
-                    pagesContent = GetAllPagesContent(password, documentGuid, info);
+                    pagesContent = GetAllPagesContent(annotator, password, documentGuid, info);
                 }
 
                 for (int i = 0; i < info.PageCount; i++)
@@ -209,7 +209,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
 
                 using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(documentGuid, GetLoadOptions(password)))
                 {
-                    using (var memoryStream = RenderPageToMemoryStream(pageNumber, documentGuid, password))
+                    using (var memoryStream = RenderPageToMemoryStream(annotator, pageNumber, documentGuid, password))
                     {
                         bytes = memoryStream.ToArray();
                     }
@@ -240,7 +240,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             }
         }
 
-        private static List<string> GetAllPagesContent(string password, string documentGuid, IDocumentInfo pages)
+        private static List<string> GetAllPagesContent(GroupDocs.Annotation.Annotator annotator, string password, string documentGuid, IDocumentInfo pages)
         {
             List<string> allPages = new List<string>();
 
@@ -248,7 +248,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             for (int i = 0; i < pages.PageCount; i++)
             {
                 byte[] bytes;
-                using (var memoryStream = RenderPageToMemoryStream(i + 1, documentGuid, password))
+                using (var memoryStream = RenderPageToMemoryStream(annotator, i + 1, documentGuid, password))
                 {
                     bytes = memoryStream.ToArray();
                 }
@@ -260,24 +260,18 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             return allPages;
         }
 
-        static MemoryStream RenderPageToMemoryStream(int pageNumberToRender, string documentGuid, string password)
+        static MemoryStream RenderPageToMemoryStream(GroupDocs.Annotation.Annotator annotator, int pageNumberToRender, string documentGuid, string password)
         {
             MemoryStream result = new MemoryStream();
 
-            using (FileStream outputStream = File.OpenRead(documentGuid))
+            PreviewOptions previewOptions = new PreviewOptions(pageNumber => result)
             {
-                using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(outputStream, GetLoadOptions(password)))
-                {
-                    PreviewOptions previewOptions = new PreviewOptions(pageNumber => result)
-                    {
-                        PreviewFormat = PreviewFormats.PNG,
-                        PageNumbers = new[] { pageNumberToRender },
-                        RenderComments = false
-                    };
+                PreviewFormat = PreviewFormats.PNG,
+                PageNumbers = new[] { pageNumberToRender },
+                RenderComments = false
+            };
 
-                    annotator.Document.GeneratePreview(previewOptions);
-                }
-            }
+            annotator.Document.GeneratePreview(previewOptions);
 
             return result;
         }
@@ -503,7 +497,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
                     using (GroupDocs.Annotation.Annotator annotator = new GroupDocs.Annotation.Annotator(outputStream, GetLoadOptions(password)))
                     {
                         IDocumentInfo info = annotator.Document.GetDocumentInfo();
-                        List<string> pagesContent = GetAllPagesContent(password, documentGuid, info);
+                        List<string> pagesContent = GetAllPagesContent(annotator, password, documentGuid, info);
 
                         for (int i = 0; i < info.PageCount; i++)
                         {
@@ -562,7 +556,6 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             LoadOptions loadOptions = new LoadOptions
             {
                 Password = password,
-                //ImportAnnotations = importAnnotations
             };
 
             return loadOptions;

--- a/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -562,7 +562,7 @@ namespace GroupDocs.Total.MVC.Products.Annotation.Controllers
             LoadOptions loadOptions = new LoadOptions
             {
                 Password = password,
-                ImportAnnotations = importAnnotations
+                //ImportAnnotations = importAnnotations
             };
 
             return loadOptions;

--- a/src/Products/Viewer/Cache/HtmlViewer.cs
+++ b/src/Products/Viewer/Cache/HtmlViewer.cs
@@ -56,6 +56,7 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Cache
             htmlViewOptions.SpreadsheetOptions = SpreadsheetOptions.ForOnePagePerSheet();
             htmlViewOptions.SpreadsheetOptions.TextOverflowMode = TextOverflowMode.HideText;
             htmlViewOptions.SpreadsheetOptions.RenderGridLines = globalConfiguration.GetViewerConfiguration().GetShowGridLines();
+            htmlViewOptions.SpreadsheetOptions.RenderHeadings = true;
 
             SetWatermarkOptions(htmlViewOptions);
 

--- a/src/Products/Viewer/Cache/PngViewer.cs
+++ b/src/Products/Viewer/Cache/PngViewer.cs
@@ -46,6 +46,8 @@ namespace GroupDocs.Total.MVC.Products.Viewer.Cache
                 createdPngViewOptions.RotatePage(passedPageNumber, rotationAngle);
             }
 
+            createdPngViewOptions.SpreadsheetOptions.RenderHeadings = true;
+
             SetWatermarkOptions(createdPngViewOptions);
 
             return createdPngViewOptions;

--- a/src/packages.config
+++ b/src/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
-  <package id="GroupDocs.Annotation" version="20.6.0" targetFramework="net45" />
+  <package id="GroupDocs.Annotation" version="20.11.0" targetFramework="net45" />
   <package id="GroupDocs.Comparison" version="20.6.0" targetFramework="net45" />
-  <package id="GroupDocs.Conversion" version="20.3.0" targetFramework="net45" />
-  <package id="GroupDocs.Editor" version="20.8.0" targetFramework="net45" />
-  <package id="GroupDocs.Metadata" version="20.9.0" targetFramework="net45" />
-  <package id="GroupDocs.Search" version="20.4.0" targetFramework="net45" />
-  <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
+  <package id="GroupDocs.Conversion" version="20.11.0" targetFramework="net45" />
+  <package id="GroupDocs.Editor" version="20.9.0" targetFramework="net45" />
+  <package id="GroupDocs.Metadata" version="20.11.0" targetFramework="net45" />
+  <package id="GroupDocs.Search" version="20.11.0" targetFramework="net45" />
+  <package id="GroupDocs.Signature" version="20.9.0" targetFramework="net45" />
   <package id="GroupDocs.Viewer" version="20.11.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
**Problem:**
- We need to update versions of some libraries.
- We could show spreadsheets headings using the back-end feature (related github-issues: https://github.com/groupdocs-total/GroupDocs.Total-Angular/issues/224, https://github.com/groupdocs-total/GroupDocs.Total-Angular/issues/221)

**Solution:**
- Updated versions some of the libraries.
- Fixed opening files in Annotation app.
- Added usage Viewer back-end feature for showing spreadsheets headings.

**Screenshots:**
For the p.3. the screenshots available in the **_required_** related PR: https://github.com/groupdocs-total/GroupDocs.Total-Angular/pull/230.