### PR TITLE
Implement the ability to load the image preview in parallel with editing metadata.

### DIFF
--- a/src/GroupDocs.Total.MVC.csproj
+++ b/src/GroupDocs.Total.MVC.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Products\Metadata\Context\MetadataContext.cs" />
     <Compile Include="Products\Metadata\Context\MetadataPathConfig.cs" />
     <Compile Include="Products\Metadata\Context\NestedPackageInfo.cs" />
+    <Compile Include="Products\Metadata\DTO\DocumentPreviewDto.cs" />
     <Compile Include="Products\Metadata\DTO\ExtractedPackageDto.cs" />
     <Compile Include="Products\Metadata\DTO\MetadataPropertyDto.cs" />
     <Compile Include="Products\Common\Entity\Web\LoadDocumentEntity.cs" />
@@ -323,6 +324,7 @@
     <Compile Include="Products\Metadata\Repositories\VCardRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\XmpMetadataRepository.cs" />
     <Compile Include="Products\Metadata\Services\FileService.cs" />
+    <Compile Include="Products\Metadata\Services\PreviewService.cs" />
     <Compile Include="Products\Metadata\Services\MetadataService.cs" />
     <Compile Include="Products\Metadata\Util\ArrayUtil.cs" />
     <Compile Include="Products\Metadata\Util\DirectoryUtils.cs" />
@@ -490,7 +492,7 @@
     <Exec WorkingDirectory="client\" Command="..\..\packages\Node-Kit.11.1.0.1\node\win\node.exe ..\..\packages\Node-Kit.11.1.0.1\npm\bin\npm-cli.js run build  --scripts-prepend-node-path" Condition=" '$(OS)' == 'Windows_NT' " />
     <Exec Command="..\packages\Node-Kit.11.1.0.1\node\win\node.exe .\node_modules\gulp\bin\gulp.js copy" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
-  <!--Target Name="AfterBuild">
+  <Target Name="AfterBuild">
     <ItemGroup>
       <ZipFiles Include="$(OutDir)**\*.*" />
       <ZipFiles Include="$(ProjectDir)Resources\**\*.*" />
@@ -505,7 +507,7 @@
       <ZipFiles Include="$(ProjectDir)Mono.WebServer2.dll" />
     </ItemGroup>
     <Zip Files="@(ZipFiles)" WorkingDirectory="$(ProjectDir)" ZipFileName="GroupDocs.Total.MVC.zip" />
-  </Target-->
+  </Target>
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
   <Target Name="CopyRoslynFiles" AfterTargets="AfterBuild" Condition="!$(Disable_CopyWebApplication) And '$(OutDir)' != '$(OutputPath)'">
     <ItemGroup>

--- a/src/GroupDocs.Total.MVC.csproj
+++ b/src/GroupDocs.Total.MVC.csproj
@@ -60,8 +60,8 @@
     <Reference Include="GroupDocs.Editor, Version=20.8.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Editor.20.8.0\lib\net20\GroupDocs.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Metadata, Version=20.9.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Metadata.20.9.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
+    <Reference Include="GroupDocs.Metadata, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Metadata.20.11.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
@@ -313,6 +313,8 @@
     <Compile Include="Products\Metadata\Repositories\Fonts\OpenTypeRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\ID3V2TagRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\IptcMetadataRepository.cs" />
+    <Compile Include="Products\Metadata\Repositories\MakerNote\CanonMakerNoteRepository.cs" />
+    <Compile Include="Products\Metadata\Repositories\MakerNote\MakerNoteRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\Matroska\MatroskaTagRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\Matroska\MatroskaTrackRepository.cs" />
     <Compile Include="Products\Metadata\Repositories\MetadataPackageRepository.cs" />
@@ -488,7 +490,7 @@
     <Exec WorkingDirectory="client\" Command="..\..\packages\Node-Kit.11.1.0.1\node\win\node.exe ..\..\packages\Node-Kit.11.1.0.1\npm\bin\npm-cli.js run build  --scripts-prepend-node-path" Condition=" '$(OS)' == 'Windows_NT' " />
     <Exec Command="..\packages\Node-Kit.11.1.0.1\node\win\node.exe .\node_modules\gulp\bin\gulp.js copy" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
-  <Target Name="AfterBuild">
+  <!--Target Name="AfterBuild">
     <ItemGroup>
       <ZipFiles Include="$(OutDir)**\*.*" />
       <ZipFiles Include="$(ProjectDir)Resources\**\*.*" />
@@ -503,7 +505,7 @@
       <ZipFiles Include="$(ProjectDir)Mono.WebServer2.dll" />
     </ItemGroup>
     <Zip Files="@(ZipFiles)" WorkingDirectory="$(ProjectDir)" ZipFileName="GroupDocs.Total.MVC.zip" />
-  </Target>
+  </Target-->
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
   <Target Name="CopyRoslynFiles" AfterTargets="AfterBuild" Condition="!$(Disable_CopyWebApplication) And '$(OutDir)' != '$(OutputPath)'">
     <ItemGroup>

--- a/src/Products/Common/Util/Comparator/FileDateComparator.cs
+++ b/src/Products/Common/Util/Comparator/FileDateComparator.cs
@@ -7,7 +7,7 @@ namespace GroupDocs.Total.MVC.Products.Common.Util.Comparator
     /// <summary>
     /// FileDateComparator.
     /// </summary>
-    public class FileDateComparator : IComparer<string>
+    public class FileDateComparator : IComparer<string> 
     {
         /// <summary>
         /// Compare file creation dates.

--- a/src/Products/Metadata/Config/MetadataConfiguration.cs
+++ b/src/Products/Metadata/Config/MetadataConfiguration.cs
@@ -16,6 +16,12 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
 
         private string outputDirectory = "DocumentSamples/Metadata/Output";
 
+        private string tempDirectory = "DocumentSamples/Metadata/Temp";
+
+        private int fileOperationTimeout;
+
+        private int fileOperationRetryCount;
+
         private int previewTimeLimit;
 
         [JsonProperty]
@@ -46,6 +52,9 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
             outputDirectory = valuesGetter.GetStringPropertyValue("outputDirectory", outputDirectory);
             outputDirectory = InitDirectory(outputDirectory);
 
+            tempDirectory = valuesGetter.GetStringPropertyValue("tempDirectory", tempDirectory);
+            tempDirectory = InitDirectory(tempDirectory);
+
             defaultDocument = valuesGetter.GetStringPropertyValue("defaultDocument", defaultDocument);
             preloadPageCount = valuesGetter.GetIntegerPropertyValue("preloadPageCount", preloadPageCount);
             previewTimeLimit = valuesGetter.GetIntegerPropertyValue("previewTimeLimit", previewTimeLimit);
@@ -53,6 +62,8 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
             cache = valuesGetter.GetBooleanPropertyValue("cache", cache);
             browse = valuesGetter.GetBooleanPropertyValue("browse", browse);
             upload = valuesGetter.GetBooleanPropertyValue("upload", upload);
+            fileOperationTimeout = valuesGetter.GetIntegerPropertyValue("fileOperationTimeout", fileOperationTimeout);
+            fileOperationRetryCount = valuesGetter.GetIntegerPropertyValue("fileOperationRetryCount", fileOperationRetryCount);
         }
 
         public void SetFilesDirectory(string filesDirectory)
@@ -90,6 +101,16 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
             return previewTimeLimit;
         }
 
+        public int GetFileOperationTimeout()
+        {
+            return fileOperationTimeout;
+        }
+
+        public int GetFileOperationRetryCount()
+        {
+            return fileOperationRetryCount;
+        }
+
         public void SetIsHtmlMode(bool isHtmlMode)
         {
             htmlMode = isHtmlMode;
@@ -102,12 +123,17 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
 
         public void SetCache(bool Cache)
         {
-            this.cache = Cache;
+            cache = Cache;
         }
 
         public bool GetCache()
         {
             return cache;
+        }
+
+        public string GetTempFilePath()
+        {
+            return Path.Combine(tempDirectory, Guid.NewGuid().ToString());
         }
 
         public string GetInputFilePath(string relativePath)
@@ -124,7 +150,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
         {
             if (Path.IsPathRooted(relativePath))
             {
-                throw new ArgumentException("Couldn't find the specified file", nameof(relativePath));
+                throw new ArgumentException("Couldn't find the specified file path", nameof(relativePath));
             }
             return Path.Combine(baseDirectory, relativePath);
         }

--- a/src/Products/Metadata/Config/MetadataConfiguration.cs
+++ b/src/Products/Metadata/Config/MetadataConfiguration.cs
@@ -148,11 +148,13 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
 
         private string GetAbsolutePath(string baseDirectory, string relativePath)
         {
-            if (Path.IsPathRooted(relativePath))
+            var absolutePath = Path.GetFullPath(Path.Combine(baseDirectory, relativePath));
+            if (!absolutePath.StartsWith(baseDirectory))
             {
                 throw new ArgumentException("Couldn't find the specified file path", nameof(relativePath));
             }
-            return Path.Combine(baseDirectory, relativePath);
+
+            return absolutePath;
         }
 
         private string InitDirectory(string path)
@@ -160,14 +162,14 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
             string absolutePath = path;
             if (!Path.IsPathRooted(path))
             {
-                absolutePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path);
+                absolutePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path));
             }
             if (!Directory.Exists(absolutePath))
             {
                 Directory.CreateDirectory(absolutePath);
             }
 
-            return absolutePath;
+            return absolutePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
     }
 }

--- a/src/Products/Metadata/Config/MetadataConfiguration.cs
+++ b/src/Products/Metadata/Config/MetadataConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using GroupDocs.Total.MVC.Products.Common.Config;
 using GroupDocs.Total.MVC.Products.Common.Util.Parser;
-using GroupDocs.Total.MVC.Products.Metadata.Util;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -12,7 +11,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
     /// </summary>
     public class MetadataConfiguration : CommonConfiguration
     {
-        private readonly string filesDirectory = "DocumentSamples/Metadata";
+        private string filesDirectory = "DocumentSamples/Metadata";
 
         private readonly string outputDirectory = "DocumentSamples/Metadata/Output";
 

--- a/src/Products/Metadata/Config/MetadataConfiguration.cs
+++ b/src/Products/Metadata/Config/MetadataConfiguration.cs
@@ -12,17 +12,17 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Config
     /// </summary>
     public class MetadataConfiguration : CommonConfiguration
     {
-        private string filesDirectory = "DocumentSamples/Metadata";
+        private readonly string filesDirectory = "DocumentSamples/Metadata";
 
-        private string outputDirectory = "DocumentSamples/Metadata/Output";
+        private readonly string outputDirectory = "DocumentSamples/Metadata/Output";
 
-        private string tempDirectory = "DocumentSamples/Metadata/Temp";
+        private readonly string tempDirectory = "DocumentSamples/Metadata/Temp";
 
-        private int fileOperationTimeout;
+        private readonly int fileOperationTimeout;
 
-        private int fileOperationRetryCount;
+        private readonly int fileOperationRetryCount;
 
-        private int previewTimeLimit;
+        private readonly int previewTimeLimit;
 
         [JsonProperty]
         private string defaultDocument = "";

--- a/src/Products/Metadata/Context/MetadataContext.cs
+++ b/src/Products/Metadata/Context/MetadataContext.cs
@@ -7,6 +7,7 @@ using GroupDocs.Total.MVC.Products.Metadata.Model;
 using GroupDocs.Total.MVC.Products.Metadata.Repositories;
 using GroupDocs.Metadata.Export;
 using System.IO;
+using GroupDocs.Metadata.Exceptions;
 
 namespace GroupDocs.Total.MVC.Products.Metadata.Context
 {
@@ -21,6 +22,10 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
         public MetadataContext(Stream fileStream, string password) : this()
         {
             metadata = new GroupDocs.Metadata.Metadata(fileStream, CreateLoadOptions(password));
+            if (metadata.FileFormat == FileFormat.Unknown)
+            {
+                throw new InvalidFormatException("Couldn't recognize the file format");
+            }
         }
 
         private MetadataContext()

--- a/src/Products/Metadata/Context/MetadataContext.cs
+++ b/src/Products/Metadata/Context/MetadataContext.cs
@@ -18,11 +18,6 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
 
         private bool disposedValue;
 
-        public MetadataContext(string filePath, string password) : this()
-        {
-            metadata = new GroupDocs.Metadata.Metadata(filePath, CreateLoadOptions(password));
-        }
-
         public MetadataContext(Stream fileStream, string password) : this()
         {
             metadata = new GroupDocs.Metadata.Metadata(fileStream, CreateLoadOptions(password));
@@ -114,6 +109,11 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
         public void Save(string filePath)
         {
             metadata.Save(filePath);
+        }
+
+        public void Save()
+        {
+            metadata.Save();
         }
 
         public void Sanitize()

--- a/src/Products/Metadata/Context/MetadataContext.cs
+++ b/src/Products/Metadata/Context/MetadataContext.cs
@@ -18,14 +18,18 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
 
         private bool disposedValue;
 
-        public MetadataContext(string filePath, string password)
+        public MetadataContext(string filePath, string password) : this()
         {
-            var loadOptions = new LoadOptions
-            {
-                Password = password == string.Empty ? null : password
-            };
+            metadata = new GroupDocs.Metadata.Metadata(filePath, CreateLoadOptions(password));
+        }
 
-            metadata = new GroupDocs.Metadata.Metadata(filePath, loadOptions);
+        public MetadataContext(Stream fileStream, string password) : this()
+        {
+            metadata = new GroupDocs.Metadata.Metadata(fileStream, CreateLoadOptions(password));
+        }
+
+        private MetadataContext()
+        {
             metadataPathConfig = new MetadataPathConfig();
         }
 
@@ -117,6 +121,12 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
             metadata.Sanitize();
         }
 
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!disposedValue)
@@ -129,10 +139,12 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Context
             }
         }
 
-        public void Dispose()
+        private LoadOptions CreateLoadOptions(string password)
         {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            return new LoadOptions
+            {
+                Password = password == string.Empty ? null : password
+            };
         }
     }
 }

--- a/src/Products/Metadata/Controllers/MetadataApiController.cs
+++ b/src/Products/Metadata/Controllers/MetadataApiController.cs
@@ -64,7 +64,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
             }
             try
             {
-                return Request.CreateResponse(HttpStatusCode.OK, previewService.LoadFileTree());
+                return Request.CreateResponse(HttpStatusCode.OK, fileService.LoadFileTree());
             }
             catch (Exception ex)
             {
@@ -235,7 +235,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
             }
             try
             {
-                return Request.CreateResponse(HttpStatusCode.OK, previewService.UploadDocument(HttpContext.Current.Request));
+                return Request.CreateResponse(HttpStatusCode.OK, fileService.UploadDocument(HttpContext.Current.Request));
             }
             catch (Exception ex)
             {

--- a/src/Products/Metadata/Controllers/MetadataApiController.cs
+++ b/src/Products/Metadata/Controllers/MetadataApiController.cs
@@ -85,6 +85,10 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
             {
                 return Request.CreateResponse(HttpStatusCode.OK, metadataService.GetPackages(postedData));
             }
+            catch (DocumentProtectedException ex)
+            {
+                return Request.CreateResponse(HttpStatusCode.Forbidden, new Resources().GenerateException(ex));
+            }
             catch (Exception ex)
             {
                 return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
@@ -160,7 +164,6 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
         [Route("metadata/loadDocumentDescription")]
         public HttpResponseMessage LoadDocumentDescription(PostedDataDto postedData)
         {
-            string password = "";
             try
             {
                 // return document description
@@ -168,7 +171,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
             }
             catch (DocumentProtectedException ex)
             {
-                return Request.CreateResponse(HttpStatusCode.Forbidden, new Resources().GenerateException(ex, password));
+                return Request.CreateResponse(HttpStatusCode.Forbidden, new Resources().GenerateException(ex));
             }
             catch (Exception ex)
             {
@@ -188,7 +191,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Controllers
             if (!string.IsNullOrEmpty(path))
             {
                 HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-                var fileStream = fileService.GetFileInputStream(path);
+                var fileStream = fileService.GetFileStream(path);
                 response.Content = new StreamContent(fileStream);
                 response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                 response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment");

--- a/src/Products/Metadata/DTO/DocumentPreviewDto.cs
+++ b/src/Products/Metadata/DTO/DocumentPreviewDto.cs
@@ -1,0 +1,18 @@
+﻿
+
+using GroupDocs.Total.MVC.Products.Common.Entity.Web;
+using Newtonsoft.Json;
+
+namespace GroupDocs.Total.MVC.Products.Metadata.DTO
+{
+    public class DocumentPreviewDto : LoadDocumentEntity
+    {
+        [JsonProperty]
+        private bool timeLimitExceeded;
+
+        public void SetTimeLimitExceeded(bool value)
+        {
+            timeLimitExceeded = value;
+        }
+    }
+}

--- a/src/Products/Metadata/Repositories/MakerNote/CanonMakerNoteRepository.cs
+++ b/src/Products/Metadata/Repositories/MakerNote/CanonMakerNoteRepository.cs
@@ -1,0 +1,21 @@
+﻿
+using GroupDocs.Metadata.Common;
+using GroupDocs.Metadata.Standards.Exif.MakerNote;
+using System.Collections.Generic;
+
+namespace GroupDocs.Total.MVC.Products.Metadata.Repositories.MakerNote
+{
+    public class CanonMakerNoteRepository : MakerNoteRepository
+    {
+        public CanonMakerNoteRepository(MetadataPackage branchPackage) : base(branchPackage)
+        {
+        }
+
+        protected override IEnumerable<MetadataPackage> GetPackages()
+        {
+            var canonMakerNote = (CanonMakerNotePackage)BranchPackage;
+            yield return canonMakerNote;
+            yield return canonMakerNote.CameraSettings;
+        }
+    }
+}

--- a/src/Products/Metadata/Repositories/MakerNote/MakerNoteRepository.cs
+++ b/src/Products/Metadata/Repositories/MakerNote/MakerNoteRepository.cs
@@ -1,0 +1,35 @@
+﻿
+using GroupDocs.Metadata.Common;
+using GroupDocs.Metadata.Formats.Image;
+using GroupDocs.Total.MVC.Products.Metadata.Model;
+using System.Collections.Generic;
+
+namespace GroupDocs.Total.MVC.Products.Metadata.Repositories.MakerNote
+{
+    public class MakerNoteRepository : MetadataPackageRepository
+    {
+        public MakerNoteRepository(MetadataPackage branchPackage) : base(branchPackage)
+        {
+        }
+
+        protected override IEnumerable<MetadataPackage> GetPackages()
+        {
+            yield return BranchPackage;
+        }
+
+        public override IEnumerable<Property> GetProperties()
+        {
+            foreach (var package in GetPackages())
+            {
+                foreach (var property in package)
+                {
+                    TiffTag tag = property as TiffTag;
+                    if (tag != null)
+                    {
+                        yield return new Property(((int)tag.TagID).ToString(), (PropertyType)property.Value.Type, property.Value.RawValue);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Products/Metadata/Repositories/MetadataRepositoryFactory.cs
+++ b/src/Products/Metadata/Repositories/MetadataRepositoryFactory.cs
@@ -4,8 +4,10 @@ using GroupDocs.Metadata.Formats.BusinessCard;
 using GroupDocs.Metadata.Formats.Font;
 using GroupDocs.Metadata.Formats.Video;
 using GroupDocs.Metadata.Standards.Exif;
+using GroupDocs.Metadata.Standards.Exif.MakerNote;
 using GroupDocs.Total.MVC.Products.Metadata.Repositories.Asf;
 using GroupDocs.Total.MVC.Products.Metadata.Repositories.Fonts;
+using GroupDocs.Total.MVC.Products.Metadata.Repositories.MakerNote;
 using GroupDocs.Total.MVC.Products.Metadata.Repositories.Matroska;
 
 namespace GroupDocs.Total.MVC.Products.Metadata.Repositories
@@ -22,6 +24,14 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Repositories
                     if (branchPackage is ExifPackage)
                     {
                         return new ExifMetadataRepository(branchPackage);
+                    }
+                    else if (branchPackage is CanonMakerNotePackage)
+                    {
+                        return new CanonMakerNoteRepository(branchPackage);
+                    }
+                    else if (branchPackage is MakerNotePackage)
+                    {
+                        return new MakerNoteRepository(branchPackage);
                     }
                     return new OneLevelMetadataRepository(branchPackage);
                 case MetadataType.Iptc:

--- a/src/Products/Metadata/Services/FileService.cs
+++ b/src/Products/Metadata/Services/FileService.cs
@@ -77,7 +77,8 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
                 Password = password
             };
 
-            using (GroupDocs.Metadata.Metadata metadata = new GroupDocs.Metadata.Metadata(filePath, loadOptions))
+            using(Stream fileStream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (GroupDocs.Metadata.Metadata metadata = new GroupDocs.Metadata.Metadata(fileStream, loadOptions))
             {
                 GroupDocs.Metadata.Common.IReadOnlyList<PageInfo> pages = metadata.GetDocumentInfo().Pages;
 

--- a/src/Products/Metadata/Services/FileService.cs
+++ b/src/Products/Metadata/Services/FileService.cs
@@ -1,9 +1,9 @@
 ﻿using GroupDocs.Total.MVC.Products.Common.Entity.Web;
 using GroupDocs.Total.MVC.Products.Common.Resources;
 using GroupDocs.Total.MVC.Products.Metadata.Config;
-using GroupDocs.Total.MVC.Products.Metadata.Context;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -39,7 +39,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
                     }
                     if (x.LastAccessTime < newFileBorder && y.LastAccessTime < newFileBorder)
                     {
-                        return string.Compare(x.Name, y.Name);
+                        return string.Compare(x.Name, y.Name, CultureInfo.InvariantCulture, CompareOptions.None);
                     }
 
                     return x.LastAccessTime >= newFileBorder ? -1 : 1;
@@ -129,7 +129,12 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
             return File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
-        public Stream GetFileStream(string relativePath, bool readOnly = true)
+        public Stream GetFileStream(string relativePath)
+        {
+            return GetFileStream(relativePath, true);
+        }
+
+        public Stream GetFileStream(string relativePath, bool readOnly)
         {
             var inputPath = metadataConfiguration.GetInputFilePath(relativePath);
             var outputPath = metadataConfiguration.GetOutputFilePath(relativePath);

--- a/src/Products/Metadata/Services/FileService.cs
+++ b/src/Products/Metadata/Services/FileService.cs
@@ -1,6 +1,13 @@
-﻿using GroupDocs.Total.MVC.Products.Metadata.Config;
+﻿using GroupDocs.Total.MVC.Products.Common.Entity.Web;
+using GroupDocs.Total.MVC.Products.Common.Resources;
+using GroupDocs.Total.MVC.Products.Metadata.Config;
 using GroupDocs.Total.MVC.Products.Metadata.Context;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Net;
+using System.Threading;
+using System.Web;
 
 namespace GroupDocs.Total.MVC.Products.Metadata.Services
 {
@@ -11,6 +18,88 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
         public FileService(MetadataConfiguration metadataConfiguration)
         {
             this.metadataConfiguration = metadataConfiguration;
+        }
+
+        public IEnumerable<FileDescriptionEntity> LoadFileTree()
+        {
+            List<FileDescriptionEntity> fileList = new List<FileDescriptionEntity>();
+            if (!string.IsNullOrEmpty(metadataConfiguration.GetFilesDirectory()))
+            {
+                var currentPath = metadataConfiguration.GetFilesDirectory();
+                var inputDirectory = new DirectoryInfo(currentPath);
+                var allFiles = inputDirectory.GetFiles();
+
+                Array.Sort(allFiles, (x, y) => DateTime.Compare(y.LastWriteTime, x.LastWriteTime));
+
+                foreach (var file in allFiles)
+                {
+                    // check if current file/folder is hidden
+                    if (!file.Attributes.HasFlag(FileAttributes.Hidden) &&
+                        !file.Name.StartsWith(".") &&
+                        !file.Attributes.HasFlag(FileAttributes.Directory))
+                    {
+                        // add object to array list
+                        fileList.Add(new FileDescriptionEntity
+                        {
+                            guid = file.Name,
+                            name = file.Name,
+                            size = file.Length,
+                        });
+                    }
+                }
+            }
+            return fileList;
+        }
+
+        public UploadedDocumentEntity UploadDocument(HttpRequest request)
+        {
+            string url = request.Form["url"];
+            // get documents storage path
+            bool rewrite = bool.Parse(request.Form["rewrite"]);
+            string fileName;
+            string tempFilePath = metadataConfiguration.GetTempFilePath();
+            if (string.IsNullOrEmpty(url))
+            {
+                // Get the uploaded document from the Files collection
+                var httpPostedFile = request.Files["file"];
+                if (httpPostedFile == null || Path.IsPathRooted(httpPostedFile.FileName))
+                {
+                    throw new ArgumentException("Could not upload the file");
+                }
+                fileName = httpPostedFile.FileName;
+
+                // Save the uploaded file to "UploadedFiles" folder
+                httpPostedFile.SaveAs(tempFilePath);
+            }
+            else
+            {
+                using (WebClient client = new WebClient())
+                {
+                    // get file name from the URL
+                    Uri uri = new Uri(url);
+                    fileName = Path.GetFileName(uri.LocalPath);
+
+                    // Download the Web resource and save it into the current filesystem folder.
+                    client.DownloadFile(url, tempFilePath);
+                }
+            }
+
+            if (rewrite)
+            {
+                string filePath = metadataConfiguration.GetInputFilePath(fileName);
+                RemoveFile(filePath);
+                RemoveFile(metadataConfiguration.GetOutputFilePath(fileName));
+                File.Move(tempFilePath, filePath);
+            }
+            else
+            {
+                File.Move(tempFilePath, Resources.GetFreeFileName(metadataConfiguration.GetFilesDirectory(), fileName));
+            }
+
+            UploadedDocumentEntity uploadedDocument = new UploadedDocumentEntity();
+            uploadedDocument.guid = Path.GetFileName(fileName);
+
+            return uploadedDocument;
         }
 
         public Stream GetSourceFileStream(string relativePath)
@@ -40,6 +129,34 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
             else
             {
                 context.Save(outputPath);
+            }
+        }
+
+        private void RemoveFile(string filePath)
+        {
+            if (File.Exists(filePath))
+            {
+                int maxReties = metadataConfiguration.GetFileOperationRetryCount();
+                int timeout = metadataConfiguration.GetFileOperationTimeout();
+                for (int i = 1; i <= maxReties; i++)
+                {
+                    try
+                    {
+                        File.Delete(filePath);
+                        break;
+                    }
+                    catch (IOException)
+                    {
+                        if (i < maxReties)
+                        {
+                            Thread.Sleep(timeout);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/Products/Metadata/Services/MetadataService.cs
+++ b/src/Products/Metadata/Services/MetadataService.cs
@@ -29,7 +29,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
 
         public IEnumerable<ExtractedPackageDto> GetPackages(PostedDataDto postedData)
         {
-            using (var inputStream = fileService.GetFileInputStream(postedData.guid))
+            using (var inputStream = fileService.GetFileStream(postedData.guid))
             using (MetadataContext context = new MetadataContext(inputStream, postedData.password))
             {
                 var packages = new List<ExtractedPackageDto>();
@@ -81,7 +81,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
 
         public byte[] ExportMetadata(PostedDataDto postedData)
         {
-            using (var inputStream = fileService.GetFileInputStream(postedData.guid))
+            using (var inputStream = fileService.GetFileStream(postedData.guid))
             using (MetadataContext context = new MetadataContext(inputStream, postedData.password))
             {
                 return context.ExportProperties();
@@ -117,11 +117,11 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
 
         private void UpdateMetadata(PostedDataDto postedData, Action<MetadataContext> updateMethod)
         {
-            using (var inputStream = fileService.GetFileInputStream(postedData.guid))
+            using (var inputStream = fileService.GetFileStream(postedData.guid, false))
             using (MetadataContext context = new MetadataContext(inputStream, postedData.password))
             {
                 updateMethod(context);
-                fileService.SaveContextToFile(context, postedData.guid);
+                context.Save();
             }
         }
     }

--- a/src/Products/Metadata/Services/MetadataService.cs
+++ b/src/Products/Metadata/Services/MetadataService.cs
@@ -31,7 +31,8 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
 
         public IEnumerable<ExtractedPackageDto> GetPackages(PostedDataDto postedData)
         {
-            using (MetadataContext context = new MetadataContext(metadataConfiguration.GetAbsolutePath(postedData.guid), postedData.password))
+            using(Stream fileStream = File.Open(metadataConfiguration.GetAbsolutePath(postedData.guid), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (MetadataContext context = new MetadataContext(fileStream, postedData.password))
             {
                 var packages = new List<ExtractedPackageDto>();
                 foreach (var package in context.GetPackages())

--- a/src/Products/Metadata/Services/PreviewService.cs
+++ b/src/Products/Metadata/Services/PreviewService.cs
@@ -1,0 +1,197 @@
+﻿using GroupDocs.Metadata.Common;
+using GroupDocs.Metadata.Options;
+using GroupDocs.Total.MVC.Products.Common.Entity.Web;
+using GroupDocs.Total.MVC.Products.Common.Resources;
+using GroupDocs.Total.MVC.Products.Metadata.Config;
+using GroupDocs.Total.MVC.Products.Metadata.DTO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace GroupDocs.Total.MVC.Products.Metadata.Services
+{
+    public class PreviewService
+    {
+        private readonly MetadataConfiguration metadataConfiguration;
+
+        private readonly FileService fileService;
+
+        public PreviewService(MetadataConfiguration metadataConfiguration, FileService fileService)
+        {
+            this.metadataConfiguration = metadataConfiguration;
+            this.fileService = fileService;
+        }
+
+        public IEnumerable<FileDescriptionEntity> LoadFileTree()
+        {
+            List<FileDescriptionEntity> fileList = new List<FileDescriptionEntity>();
+            if (!string.IsNullOrEmpty(metadataConfiguration.GetFilesDirectory()))
+            {
+                var currentPath = metadataConfiguration.GetFilesDirectory();
+                var inputDirectory = new DirectoryInfo(currentPath);
+                var allFiles = inputDirectory.GetFiles();
+
+                Array.Sort(allFiles, (x, y) => DateTime.Compare(y.CreationTime, x.CreationTime));
+
+                foreach (var file in allFiles)
+                {
+                    // check if current file/folder is hidden
+                    if (!file.Attributes.HasFlag(FileAttributes.Hidden) &&
+                        !file.Name.StartsWith(".") &&
+                        !file.Attributes.HasFlag(FileAttributes.Directory))
+                    {
+                        // add object to array list
+                        fileList.Add(new FileDescriptionEntity
+                        {
+                            guid = file.Name,
+                            name = file.Name,
+                            size = file.Length,
+                        });
+                    }
+                }
+            }
+            return fileList;
+        }
+
+        public DocumentPreviewDto LoadDocument(PostedDataDto postedData)
+        {
+            string password = string.IsNullOrEmpty(postedData.password) ? null : postedData.password;
+            var documentPreview = new DocumentPreviewDto();
+
+            // set password for protected document
+            var loadOptions = new LoadOptions
+            {
+                Password = password
+            };
+
+            using (Stream fileStream = fileService.GetSourceFileStream(postedData.guid))
+            using (GroupDocs.Metadata.Metadata metadata = new GroupDocs.Metadata.Metadata(fileStream, loadOptions))
+            {
+                GroupDocs.Metadata.Common.IReadOnlyList<PageInfo> pages = metadata.GetDocumentInfo().Pages;
+
+                using (MemoryStream stream = new MemoryStream())
+                {
+                    PreviewOptions previewOptions = new PreviewOptions(pageNumber => stream, (pageNumber, pageStream) => { });
+                    previewOptions.PreviewFormat = PreviewOptions.PreviewFormats.PNG;
+
+                    int pageCount = pages.Count;
+                    if (metadataConfiguration.GetPreloadPageCount() > 0)
+                    {
+                        pageCount = metadataConfiguration.GetPreloadPageCount();
+                    }
+
+                    bool completed = ExecuteWithTimeLimit(TimeSpan.FromMilliseconds(metadataConfiguration.GetPreviewTimeLimit()), () =>
+                    {
+                        for (int i = 0; i < pageCount; i++)
+                        {
+                            previewOptions.PageNumbers = new[] { i + 1 };
+                            try
+                            {
+                                metadata.GeneratePreview(previewOptions);
+                            }
+                            catch (NotSupportedException)
+                            {
+                                break;
+                            }
+
+                            PageDescriptionEntity pageData = GetPageDescriptionEntities(pages[i]);
+                            string encodedImage = Convert.ToBase64String(stream.ToArray());
+                            pageData.SetData(encodedImage);
+                            documentPreview.SetPages(pageData);
+                            stream.SetLength(0);
+                        }
+                    });
+
+                    documentPreview.SetTimeLimitExceeded(!completed);
+                }
+            }
+
+            documentPreview.SetGuid(postedData.guid);
+
+            // return document description
+            return documentPreview;
+        }
+
+        public UploadedDocumentEntity UploadDocument(HttpRequest request)
+        {
+            string url = request.Form["url"];
+            // get documents storage path
+            string documentStoragePath = metadataConfiguration.GetFilesDirectory();
+            bool rewrite = bool.Parse(request.Form["rewrite"]);
+            string fileSavePath = string.Empty;
+            if (string.IsNullOrEmpty(url))
+            {
+                // Get the uploaded document from the Files collection
+                var httpPostedFile = request.Files["file"];
+                if (httpPostedFile == null || Path.IsPathRooted(httpPostedFile.FileName))
+                {
+                    throw new ArgumentException("Could not upload the file");
+                }
+                if (rewrite)
+                {
+                    // Get the complete file path
+                    fileSavePath = Path.Combine(documentStoragePath, httpPostedFile.FileName);
+                }
+                else
+                {
+                    fileSavePath = Resources.GetFreeFileName(documentStoragePath, httpPostedFile.FileName);
+                }
+
+                // Save the uploaded file to "UploadedFiles" folder
+                httpPostedFile.SaveAs(fileSavePath);
+
+            }
+            else
+            {
+                using (WebClient client = new WebClient())
+                {
+                    // get file name from the URL
+                    Uri uri = new Uri(url);
+                    string fileName = Path.GetFileName(uri.LocalPath);
+                    if (rewrite)
+                    {
+                        // Get the complete file path
+                        fileSavePath = Path.Combine(documentStoragePath, fileName);
+                    }
+                    else
+                    {
+                        fileSavePath = Resources.GetFreeFileName(documentStoragePath, fileName);
+                    }
+                    // Download the Web resource and save it into the current filesystem folder.
+                    client.DownloadFile(url, fileSavePath);
+                }
+            }
+
+            UploadedDocumentEntity uploadedDocument = new UploadedDocumentEntity();
+            uploadedDocument.guid = Path.GetFileName(fileSavePath);
+
+            return uploadedDocument;
+        }
+
+        private bool ExecuteWithTimeLimit(TimeSpan timeSpan, Action codeBlock)
+        {
+            try
+            {
+                Task task = Task.Factory.StartNew(() => codeBlock());
+                task.Wait(timeSpan);
+                return task.IsCompleted;
+            }
+            catch (AggregateException ae)
+            {
+                throw ae.InnerExceptions[0];
+            }
+        }
+
+        private PageDescriptionEntity GetPageDescriptionEntities(PageInfo page)
+        {
+            PageDescriptionEntity pageDescriptionEntity = new PageDescriptionEntity();
+            pageDescriptionEntity.number = page.PageNumber;
+            pageDescriptionEntity.height = page.Height;
+            pageDescriptionEntity.width = page.Width;
+            return pageDescriptionEntity;
+        }
+    }
+}

--- a/src/Products/Metadata/Services/PreviewService.cs
+++ b/src/Products/Metadata/Services/PreviewService.cs
@@ -1,15 +1,11 @@
 ﻿using GroupDocs.Metadata.Common;
 using GroupDocs.Metadata.Options;
 using GroupDocs.Total.MVC.Products.Common.Entity.Web;
-using GroupDocs.Total.MVC.Products.Common.Resources;
 using GroupDocs.Total.MVC.Products.Metadata.Config;
 using GroupDocs.Total.MVC.Products.Metadata.DTO;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace GroupDocs.Total.MVC.Products.Metadata.Services
 {
@@ -23,37 +19,6 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
         {
             this.metadataConfiguration = metadataConfiguration;
             this.fileService = fileService;
-        }
-
-        public IEnumerable<FileDescriptionEntity> LoadFileTree()
-        {
-            List<FileDescriptionEntity> fileList = new List<FileDescriptionEntity>();
-            if (!string.IsNullOrEmpty(metadataConfiguration.GetFilesDirectory()))
-            {
-                var currentPath = metadataConfiguration.GetFilesDirectory();
-                var inputDirectory = new DirectoryInfo(currentPath);
-                var allFiles = inputDirectory.GetFiles();
-
-                Array.Sort(allFiles, (x, y) => DateTime.Compare(y.CreationTime, x.CreationTime));
-
-                foreach (var file in allFiles)
-                {
-                    // check if current file/folder is hidden
-                    if (!file.Attributes.HasFlag(FileAttributes.Hidden) &&
-                        !file.Name.StartsWith(".") &&
-                        !file.Attributes.HasFlag(FileAttributes.Directory))
-                    {
-                        // add object to array list
-                        fileList.Add(new FileDescriptionEntity
-                        {
-                            guid = file.Name,
-                            name = file.Name,
-                            size = file.Length,
-                        });
-                    }
-                }
-            }
-            return fileList;
         }
 
         public DocumentPreviewDto LoadDocument(PostedDataDto postedData)
@@ -70,7 +35,7 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
             using (Stream fileStream = fileService.GetSourceFileStream(postedData.guid))
             using (GroupDocs.Metadata.Metadata metadata = new GroupDocs.Metadata.Metadata(fileStream, loadOptions))
             {
-                GroupDocs.Metadata.Common.IReadOnlyList<PageInfo> pages = metadata.GetDocumentInfo().Pages;
+                IReadOnlyList<PageInfo> pages = metadata.GetDocumentInfo().Pages;
 
                 using (MemoryStream stream = new MemoryStream())
                 {
@@ -113,62 +78,6 @@ namespace GroupDocs.Total.MVC.Products.Metadata.Services
 
             // return document description
             return documentPreview;
-        }
-
-        public UploadedDocumentEntity UploadDocument(HttpRequest request)
-        {
-            string url = request.Form["url"];
-            // get documents storage path
-            string documentStoragePath = metadataConfiguration.GetFilesDirectory();
-            bool rewrite = bool.Parse(request.Form["rewrite"]);
-            string fileSavePath = string.Empty;
-            if (string.IsNullOrEmpty(url))
-            {
-                // Get the uploaded document from the Files collection
-                var httpPostedFile = request.Files["file"];
-                if (httpPostedFile == null || Path.IsPathRooted(httpPostedFile.FileName))
-                {
-                    throw new ArgumentException("Could not upload the file");
-                }
-                if (rewrite)
-                {
-                    // Get the complete file path
-                    fileSavePath = Path.Combine(documentStoragePath, httpPostedFile.FileName);
-                }
-                else
-                {
-                    fileSavePath = Resources.GetFreeFileName(documentStoragePath, httpPostedFile.FileName);
-                }
-
-                // Save the uploaded file to "UploadedFiles" folder
-                httpPostedFile.SaveAs(fileSavePath);
-
-            }
-            else
-            {
-                using (WebClient client = new WebClient())
-                {
-                    // get file name from the URL
-                    Uri uri = new Uri(url);
-                    string fileName = Path.GetFileName(uri.LocalPath);
-                    if (rewrite)
-                    {
-                        // Get the complete file path
-                        fileSavePath = Path.Combine(documentStoragePath, fileName);
-                    }
-                    else
-                    {
-                        fileSavePath = Resources.GetFreeFileName(documentStoragePath, fileName);
-                    }
-                    // Download the Web resource and save it into the current filesystem folder.
-                    client.DownloadFile(url, fileSavePath);
-                }
-            }
-
-            UploadedDocumentEntity uploadedDocument = new UploadedDocumentEntity();
-            uploadedDocument.guid = Path.GetFileName(fileSavePath);
-
-            return uploadedDocument;
         }
 
         private bool ExecuteWithTimeLimit(TimeSpan timeSpan, Action codeBlock)

--- a/src/Products/Metadata/Util/DirectoryUtils.cs
+++ b/src/Products/Metadata/Util/DirectoryUtils.cs
@@ -1,19 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.IO;
+﻿using System.IO;
 
 namespace GroupDocs.Total.MVC.Products.Metadata.Util
 {
     public static class DirectoryUtils
     {
-        public static bool IsFullPath(string path)
-        {
-            return !string.IsNullOrWhiteSpace(path)
-                && path.IndexOfAny(Path.GetInvalidPathChars().ToArray()) == -1
-                && Path.IsPathRooted(path)
-                && !Path.GetPathRoot(path).Equals(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal);
-        }
-
         public static void MoveFile(string source, string destination)
         {
             if (File.Exists(destination))

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -234,15 +234,15 @@ metadata:
   defaultDocument: ''
   # Time limit for preview generation (in milliseconds)
   # Preview generation will be canceled if the time limit exceeded
-  previewTimeLimit: 1000000
+  previewTimeLimit: 50000
   # Pages preload
-  # How many pages from a document should be loaded, remaining pages will be loaded on page scrolling
-  # Set 0 to load all pages at once  
+  # How many pages from a document should be loaded
+  # Set 0 to load all pages
   preloadPageCount: 0
   # The number of retries to complete a file operation if the file is being used by another process
-  fileOperationRetryCount: 3
+  fileOperationRetryCount: 5
   # The timeout before each retry to complete a file operation if the file is being used by another process
-  fileOperationTimeout: 500
+  fileOperationTimeout: 1000
   # HTML rendering mode
   # Set false for image mode
   # Set true for HTML mode

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -226,9 +226,15 @@ metadata:
   # Files directory path
   # Absolute path to files directory
   filesDirectory: 'DocumentSamples/Metadata'
+  # Output directory path
+  # Absolute path to Output directory
+  outputDirectory: 'DocumentSamples/Metadata/Output'
   # Default document
   # Absolute path to default document
   defaultDocument: ''
+  # Time limit for preview generation (in milliseconds)
+  # Preview generation will be canceled if the time limit exceeded
+  previewTimeLimit: 1000000
   # Pages preload
   # How many pages from a document should be loaded, remaining pages will be loaded on page scrolling
   # Set 0 to load all pages at once

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -237,8 +237,12 @@ metadata:
   previewTimeLimit: 1000000
   # Pages preload
   # How many pages from a document should be loaded, remaining pages will be loaded on page scrolling
-  # Set 0 to load all pages at once
+  # Set 0 to load all pages at once  
   preloadPageCount: 0
+  # The number of retries to complete a file operation if the file is being used by another process
+  fileOperationRetryCount: 3
+  # The timeout before each retry to complete a file operation if the file is being used by another process
+  fileOperationTimeout: 500
   # HTML rendering mode
   # Set false for image mode
   # Set true for HTML mode

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -229,12 +229,15 @@ metadata:
   # Output directory path
   # Absolute path to Output directory
   outputDirectory: 'DocumentSamples/Metadata/Output'
+  # Temp directory path
+  # Absolute path to directory for temporary files
+  tempDirectory: 'DocumentSamples/Metadata/Temp'
   # Default document
   # Absolute path to default document
   defaultDocument: ''
   # Time limit for preview generation (in milliseconds)
   # Preview generation will be canceled if the time limit exceeded
-  previewTimeLimit: 50000
+  previewTimeLimit: 5000
   # Pages preload
   # How many pages from a document should be loaded
   # Set 0 to load all pages

--- a/src/packages.config
+++ b/src/packages.config
@@ -6,7 +6,7 @@
   <package id="GroupDocs.Comparison" version="20.6.0" targetFramework="net45" />
   <package id="GroupDocs.Conversion" version="20.3.0" targetFramework="net45" />
   <package id="GroupDocs.Editor" version="20.8.0" targetFramework="net45" />
-  <package id="GroupDocs.Metadata" version="20.9.0" targetFramework="net45" />
+  <package id="GroupDocs.Metadata" version="20.11.0" targetFramework="net45" />
   <package id="GroupDocs.Search" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Viewer" version="20.7.0" targetFramework="net45" />


### PR DESCRIPTION
Once document metadata is loaded the application starts creating a file preview. At the same time, the fetched metadata properties become available for viewing and editing. If the preview generation process reaches a certain time limit (specified in the config), it is dropped by the server. In this case, an appropriate notification is displayed to the user, but metadata remains available in full. If the process is dropped, but some preview pages are already generated, they are displayed to the user.